### PR TITLE
Expand tests

### DIFF
--- a/cypress/integration/Settings/partialsViewMacroFiles.ts
+++ b/cypress/integration/Settings/partialsViewMacroFiles.ts
@@ -39,7 +39,7 @@ context('Partial View Macro Files', () => {
 
     //Assert
     cy.umbracoSuccessNotification().should('be.visible');
-    cy.umbracoMacroExists(name).then(exists => { expect(exists).to.be.true; });
+    cy.umbracoMacroExists(name).should('be.true');
 
     //Clean up
     cleanup(name);
@@ -62,7 +62,7 @@ context('Partial View Macro Files', () => {
 
     // Assert
     cy.umbracoSuccessNotification().should('be.visible');
-    cy.umbracoMacroExists(name).then(exists => { expect(exists).to.be.false; });
+    cy.umbracoMacroExists(name).should('be.false');
 
     // Clean
     cleanup(name);
@@ -88,7 +88,7 @@ context('Partial View Macro Files', () => {
 
     // Assert
     cy.umbracoSuccessNotification().should('be.visible');
-    cy.umbracoMacroExists(name).then(exists => { expect(exists).to.be.true; });
+    cy.umbracoMacroExists(name).should('be.true');
 
     // Clean
     cleanup(name);

--- a/cypress/integration/Settings/partialsViewMacroFiles.ts
+++ b/cypress/integration/Settings/partialsViewMacroFiles.ts
@@ -142,7 +142,7 @@ context('Partial View Macro Files', () => {
     cy.umbracoTreeItem("settings", ["Partial View Macro Files", fullName]).click();
 
     // Type an edit
-    cy.get('.ace_content').type(" // test");
+    cy.get('.ace_text-input').type(" // test", {force:true});
     // Save
     cy.get('.btn-success').click();
 

--- a/cypress/integration/Settings/partialsViews.ts
+++ b/cypress/integration/Settings/partialsViews.ts
@@ -75,6 +75,10 @@ context('Partial Views', () => {
     cy.umbracoContextMenuAction("action-create").click();
     cy.get('.menu-label').first().click();
 
+    // The test would fail intermittently, most likely because the editor didn't have time to load
+    // This should ensure that the editor is loaded and the test should no longer fail unexpectedly. 
+    cy.get('.ace_content', {timeout: 5000}).should('exist');  
+
     // Click save
     cy.get('.btn-success').click();
 

--- a/cypress/integration/Settings/partialsViews.ts
+++ b/cypress/integration/Settings/partialsViews.ts
@@ -36,7 +36,7 @@ context('Partial Views', () => {
 
     //Assert
     cy.umbracoSuccessNotification().should('be.visible');
-    cy.umbracoPartialViewExists(fileName).then(exists => { expect(exists).to.be.true; });
+    cy.umbracoPartialViewExists(fileName).should('be.true')
 
     //Clean up
     cy.umbracoEnsurePartialViewNameNotExists(fileName);
@@ -63,7 +63,7 @@ context('Partial Views', () => {
 
     // Assert
     cy.umbracoSuccessNotification().should('be.visible');
-    cy.umbracoPartialViewExists(fileName).then(exists => { expect(exists).to.be.true; });
+    cy.umbracoPartialViewExists(fileName).should('be.true')
 
     // Clean up
     cy.umbracoEnsurePartialViewNameNotExists(fileName);
@@ -109,7 +109,7 @@ context('Partial Views', () => {
 
     // Assert 
     cy.contains(fileName).should('not.exist');
-    cy.umbracoPartialViewExists(fileName).then(exists => { expect(exists).to.be.false; });
+    cy.umbracoPartialViewExists(fileName).should('be.false');
 
     // Clean 
     cy.umbracoEnsurePartialViewNameNotExists(fileName);

--- a/cypress/integration/Settings/partialsViews.ts
+++ b/cypress/integration/Settings/partialsViews.ts
@@ -132,7 +132,7 @@ context('Partial Views', () => {
     // Open partial view
     cy.umbracoTreeItem("settings", ["Partial Views", fileName]).click();
     // Edit
-    cy.get('.ace_content').type("var num = 5;");
+    cy.get('.ace_text-input').type("var num = 5;", {force:true});
     cy.get('.btn-success').click();
 
     // Assert

--- a/cypress/integration/Settings/scripts.ts
+++ b/cypress/integration/Settings/scripts.ts
@@ -68,7 +68,7 @@ context('Scripts', () => {
   it('Update JavaScript file', () => {
     const name = "TestEditJavaScriptFile";
     const nameEdit = "Edited";
-    var fileName = name + ".js";
+    let fileName = name + ".js";
 
     const originalContent = 'console.log("A script);\n';
     const edit = 'alert("content");';

--- a/cypress/integration/Settings/scripts.ts
+++ b/cypress/integration/Settings/scripts.ts
@@ -33,6 +33,8 @@ context('Scripts', () => {
 
     //Assert
     cy.umbracoSuccessNotification().should('be.visible');
+    cy.umbracoScriptExists(fileName).then(exists => { expect(exists).to.be.true });
+
 
     //Clean up
     cy.umbracoEnsureScriptNameNotExists(fileName);
@@ -58,7 +60,7 @@ context('Scripts', () => {
     cy.umbracoButtonByLabelKey("general_ok").click();
 
     cy.contains(fileName).should('not.exist');
-    // TODO: assert with db call that script has actually been deleted
+    cy.umbracoScriptExists(name).then(exists => { expect(exists).to.be.false });
 
     cy.umbracoEnsureScriptNameNotExists(fileName);
   });

--- a/cypress/integration/Settings/scripts.ts
+++ b/cypress/integration/Settings/scripts.ts
@@ -33,7 +33,7 @@ context('Scripts', () => {
 
     //Assert
     cy.umbracoSuccessNotification().should('be.visible');
-    cy.umbracoScriptExists(fileName).then(exists => { expect(exists).to.be.true });
+    cy.umbracoScriptExists(fileName).should('be.true');
 
 
     //Clean up
@@ -60,7 +60,7 @@ context('Scripts', () => {
     cy.umbracoButtonByLabelKey("general_ok").click();
 
     cy.contains(fileName).should('not.exist');
-    cy.umbracoScriptExists(name).then(exists => { expect(exists).to.be.false });
+    cy.umbracoScriptExists(name).should('be.false');
 
     cy.umbracoEnsureScriptNameNotExists(fileName);
   });
@@ -95,7 +95,7 @@ context('Scripts', () => {
     cy.get('.btn-success').click();
 
     cy.umbracoSuccessNotification().should('be.visible');
-    cy.umbracoVerifyScriptContent(fileName, expected).then((result) => { expect(result).to.be.true });
+    cy.umbracoVerifyScriptContent(fileName, expected).should('be.true');
 
     cy.umbracoEnsureScriptNameNotExists(fileName);
   });
@@ -114,7 +114,7 @@ context('Scripts', () => {
     cy.umbracoButtonByLabelKey("general_ok").click();
 
     cy.contains(folderName).should('not.exist');
-    cy.umbracoScriptExists(folderName).then(exists => { expect(exists).to.be.false });
+    cy.umbracoScriptExists(folderName).should('be.false')
 
     cy.umbracoEnsureScriptNameNotExists(folderName);
   });

--- a/cypress/integration/Settings/scripts.ts
+++ b/cypress/integration/Settings/scripts.ts
@@ -67,7 +67,8 @@ context('Scripts', () => {
 
   it('Update JavaScript file', () => {
     const name = "TestEditJavaScriptFile";
-    const fileName = name + ".js";
+    const nameEdit = "Edited";
+    var fileName = name + ".js";
 
     const originalContent = 'console.log("A script);\n';
     const edit = 'alert("content");';
@@ -84,13 +85,38 @@ context('Scripts', () => {
     navigateToSettings();
     cy.umbracoTreeItem("settings", ["Scripts", fileName]).click();
     
+
     cy.get('.ace_text-input').type(edit, { force: true });
+
+    // Since scripts has no alias it should be safe to not use umbracoEditorHeaderName
+    // umbracoEditorHeaderName does not like {backspace}
+    cy.get('#headerName').type("{backspace}{backspace}{backspace}" + nameEdit).should('have.value', name+nameEdit);
+    fileName = name + nameEdit + ".js";
     cy.get('.btn-success').click();
 
     cy.umbracoSuccessNotification().should('be.visible');
     cy.umbracoVerifyScriptContent(fileName, expected).then((result) => { expect(result).to.be.true });
 
     cy.umbracoEnsureScriptNameNotExists(fileName);
+  });
+
+  it('Can Delete folder', () => {
+    const folderName = "TestFolder";
+
+    // The way scripts and folders are fetched and deleted are identical
+    cy.umbracoEnsureScriptNameNotExists(folderName);
+    cy.saveFolder('scripts', folderName);
+
+    navigateToSettings()
+
+    cy.umbracoTreeItem("settings", ["Scripts", folderName]).rightclick();
+    cy.umbracoContextMenuAction("action-delete").click();
+    cy.umbracoButtonByLabelKey("general_ok").click();
+
+    cy.contains(folderName).should('not.exist');
+    cy.umbracoScriptExists(folderName).then(exists => { expect(exists).to.be.false });
+
+    cy.umbracoEnsureScriptNameNotExists(folderName);
   });
 
 });

--- a/cypress/integration/Settings/scripts.ts
+++ b/cypress/integration/Settings/scripts.ts
@@ -1,9 +1,16 @@
 /// <reference types="Cypress" />
+import{ ScriptBuilder } from "../../../src"
+
 context('Scripts', () => {
 
   beforeEach(() => {
     cy.umbracoLogin(Cypress.env('username'), Cypress.env('password'));
-  });
+  }); 
+  
+  function navigateToSettings() {
+    cy.umbracoSection('settings');
+    cy.get('li .umb-tree-root:contains("Settings")').should("be.visible");
+  }
 
   it('Create new JavaScript file', () => {
     const name = "TestScript";
@@ -11,8 +18,7 @@ context('Scripts', () => {
 
    cy.umbracoEnsureScriptNameNotExists(fileName);
 
-    cy.umbracoSection('settings');
-    cy.get('li .umb-tree-root:contains("Settings")').should("be.visible");
+    navigateToSettings()
 
     cy.umbracoTreeItem("settings", ["Scripts"]).rightclick();
 
@@ -30,6 +36,31 @@ context('Scripts', () => {
 
     //Clean up
     cy.umbracoEnsureScriptNameNotExists(fileName);
-   });
+  });
+  
+  it('Delete a JavaScript file', () => {
+    const name = "TestDeleteScriptFile";
+    const fileName = name + ".js";
+
+    cy.umbracoEnsureScriptNameNotExists(fileName);
+
+    const script = new ScriptBuilder()
+      .withName(name)
+      .withContent('alert("this is content");')
+      .build();
+    
+    cy.saveScript(script);
+    
+    navigateToSettings()
+
+    cy.umbracoTreeItem("settings", ["Scripts", fileName]).rightclick();
+    cy.umbracoContextMenuAction("action-delete").click();
+    cy.umbracoButtonByLabelKey("general_ok").click();
+
+    cy.contains(fileName).should('not.exist');
+    // TODO: assert with db call that script has actually been deleted
+
+    cy.umbracoEnsureScriptNameNotExists(fileName);
+  });
 
 });

--- a/cypress/integration/Settings/scripts.ts
+++ b/cypress/integration/Settings/scripts.ts
@@ -16,7 +16,7 @@ context('Scripts', () => {
     const name = "TestScript";
     const fileName = name + ".js";
 
-   cy.umbracoEnsureScriptNameNotExists(fileName);
+    cy.umbracoEnsureScriptNameNotExists(fileName);
 
     navigateToSettings()
 
@@ -61,6 +61,34 @@ context('Scripts', () => {
 
     cy.contains(fileName).should('not.exist');
     cy.umbracoScriptExists(name).then(exists => { expect(exists).to.be.false });
+
+    cy.umbracoEnsureScriptNameNotExists(fileName);
+  });
+
+  it('Update JavaScript file', () => {
+    const name = "TestEditJavaScriptFile";
+    const fileName = name + ".js";
+
+    const originalContent = 'console.log("A script);\n';
+    const edit = 'alert("content");';
+    const expected = originalContent + edit;
+
+    cy.umbracoEnsureScriptNameNotExists(fileName);
+    
+    const script = new ScriptBuilder()
+      .withName(name)
+      .withContent(originalContent)
+      .build();
+    cy.saveScript(script);
+
+    navigateToSettings();
+    cy.umbracoTreeItem("settings", ["Scripts", fileName]).click();
+    
+    cy.get('.ace_text-input').type(edit, { force: true });
+    cy.get('.btn-success').click();
+
+    cy.umbracoSuccessNotification().should('be.visible');
+    cy.umbracoVerifyScriptContent(fileName, expected).then((result) => { expect(result).to.be.true });
 
     cy.umbracoEnsureScriptNameNotExists(fileName);
   });

--- a/cypress/integration/Settings/templates.ts
+++ b/cypress/integration/Settings/templates.ts
@@ -30,7 +30,7 @@ context('Templates', () => {
     /* Make an edit, if you don't the file will be create twice,
     only happens in testing though, probably because the test is too fast
     Certifiably mega wonk regardless */
-    cy.get('.ace_content').type("var num = 5;");
+    cy.get('.ace_text-input').type("var num = 5;", {force:true});
 
     //Save
     cy.get('.btn-success').click();
@@ -59,7 +59,7 @@ context('Templates', () => {
     // Open partial view
     cy.umbracoTreeItem("settings", ["Templates", name]).click();
     // Edit
-    cy.get('.ace_content').type(edit);
+    cy.get('.ace_text-input').type(edit, {force:true});
     // Navigate away
     cy.umbracoSection('content');
     // Click stay button 
@@ -91,7 +91,7 @@ context('Templates', () => {
     // Open partial view
     cy.umbracoTreeItem("settings", ["Templates", name]).click();
     // Edit
-    cy.get('.ace_content').type(edit);
+    cy.get('.ace_text-input').type(edit, {force:true});
     // Navigate away
     cy.umbracoSection('content');
     // Click discard

--- a/cypress/integration/Settings/templates.ts
+++ b/cypress/integration/Settings/templates.ts
@@ -27,12 +27,7 @@ context('Templates', () => {
     createTemplate();
     //Type name
     cy.umbracoEditorHeaderName(name);
-    /* Make an edit, if you don't the file will be create twice,
-    only happens in testing though, probably because the test is too fast
-    Certifiably mega wonk regardless */
-    /* And now we hav to click as well, this auto save thing is a pain... */ 
-    cy.get('.ace_content').click();
-    cy.get('.ace_text-input').type("var num = 5;", {force:true});
+
     //Save
     cy.get('.btn-success').click();
 
@@ -40,6 +35,9 @@ context('Templates', () => {
     cy.umbracoSuccessNotification().should('be.visible');
 
     //Clean up
+    cy.umbracoEnsureTemplateNameNotExists(name);
+    // Trying to make the test not create two templates tends to do more bad than good
+    // Simply just deleting botht the templates seems to work better.
     cy.umbracoEnsureTemplateNameNotExists(name);
   });
 

--- a/cypress/integration/Settings/templates.ts
+++ b/cypress/integration/Settings/templates.ts
@@ -30,8 +30,9 @@ context('Templates', () => {
     /* Make an edit, if you don't the file will be create twice,
     only happens in testing though, probably because the test is too fast
     Certifiably mega wonk regardless */
+    /* And now we hav to click as well, this auto save thing is a pain... */ 
+    cy.get('.ace_content').click();
     cy.get('.ace_text-input').type("var num = 5;", {force:true});
-
     //Save
     cy.get('.btn-success').click();
 
@@ -63,7 +64,7 @@ context('Templates', () => {
     // Navigate away
     cy.umbracoSection('content');
     // Click stay button 
-    cy.get('umb-button[label="Stay"] button:enabled').click();
+    cy.get('umb-button[label="Stay"] button:enabled', {timeout: 5000}).click();
 
     // Assert
     // That the same document is open
@@ -95,7 +96,7 @@ context('Templates', () => {
     // Navigate away
     cy.umbracoSection('content');
     // Click discard
-    cy.get('umb-button[label="Discard changes"] button:enabled').click();
+    cy.get('umb-button[label="Discard changes"] button:enabled', {timeout: 5000}).click();
     // Navigate back
     cy.umbracoSection('settings');
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
-    "cypress": "^4.12.1",
+    "cypress": "^5.0.0",
     "cross-env": "^7.0.2",
     "ncp": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@typescript-eslint/parser": "^3.9.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
-    "cypress": "^4.12.1",
+    "cypress": "^5.0.0",
     "cypress-file-upload": "^4.0.7",
     "cypress-wait-until": "^1.7.1",
     "eslint": "^7.6.0",
@@ -67,7 +67,7 @@
     "testdouble": "^3.16.1",
     "ts-jest": "^26.2.0",
     "ts-loader": "^8.0.2",
-    "typescript": "~3.9.7"
+    "typescript": "^3.9.7"
   },
   "peerDependencies": {
     "cypress": "^4.12.1",

--- a/src/cms/builders/scriptbuilder.ts
+++ b/src/cms/builders/scriptbuilder.ts
@@ -1,0 +1,33 @@
+export class ScriptBuilder{
+  content;
+  fileType;
+  id;
+  name;
+  notifications;
+  path;
+  snippet;
+  virtualPath;
+
+  withContent(content) {
+    this.content = content;
+    return this;
+  }
+
+  withName(name) {
+    this.name = name;
+    return this;
+  }
+
+  build() {
+    return {
+      name: this.name,
+      content: this.content,
+      filetype: this.fileType || 'scripts',
+      id: this.id || "0",
+      notifications: this.notifications || [],
+      path: this.path || null,
+      snippet: this.snippet || null,
+      virtualPath: this.virtualPath || "/scripts/"
+    }
+  }
+}

--- a/src/cypress/commands/chainable.ts
+++ b/src/cypress/commands/chainable.ts
@@ -63,8 +63,10 @@ declare global {
       umbracoVerifyScriptContent: (name: string, expected: string) => Chainable<boolean>;
       saveMacro: (name: string) => Chainable<any>;
       umbracoPartialViewExists: (name: string) => Chainable<boolean>;
-      savePartialView: (name: any) => Chainable<void>;
+      savePartialView: (view: any) => Chainable<void>;
       umbracoErrorNotification: () => Chainable<any>;
+      umbracoMacroExists: (name: string) => Chainable<boolean>;
+      savePartialViewMacro: (macro: any) => Chainable<any>;
     }
   }
 }

--- a/src/cypress/commands/chainable.ts
+++ b/src/cypress/commands/chainable.ts
@@ -57,6 +57,10 @@ declare global {
       umbracoButtonByLabelKey: (name: string) => Chainable<void>;
       umbracoEditorHeaderName: (name: string) => Chainable<void>;
       upload(fileOrArray, processingOpts?): Chainable<Subject>;
+      umbracoScriptExists: (name: string) => Chainable<any>;
+      saveScript: (script: any) => Chainable<void>;
+      saveFolder: (section: string ,folderName: string) => Chainable<void>;
+      umbracoVerifyScriptContent: (name: string, expected: string) => Chainable<any>;
     }
   }
 }

--- a/src/cypress/commands/chainable.ts
+++ b/src/cypress/commands/chainable.ts
@@ -67,6 +67,7 @@ declare global {
       umbracoErrorNotification: () => Chainable<any>;
       umbracoMacroExists: (name: string) => Chainable<boolean>;
       savePartialViewMacro: (macro: any) => Chainable<any>;
+      umbracoApiRequest: (url: string, method: string, body: any) => Chainable<any>;
     }
   }
 }

--- a/src/cypress/commands/chainable.ts
+++ b/src/cypress/commands/chainable.ts
@@ -57,10 +57,14 @@ declare global {
       umbracoButtonByLabelKey: (name: string) => Chainable<void>;
       umbracoEditorHeaderName: (name: string) => Chainable<void>;
       upload(fileOrArray, processingOpts?): Chainable<Subject>;
-      umbracoScriptExists: (name: string) => Chainable<any>;
+      umbracoScriptExists: (name: string) => Chainable<boolean>;
       saveScript: (script: any) => Chainable<void>;
       saveFolder: (section: string ,folderName: string) => Chainable<void>;
-      umbracoVerifyScriptContent: (name: string, expected: string) => Chainable<any>;
+      umbracoVerifyScriptContent: (name: string, expected: string) => Chainable<boolean>;
+      saveMacro: (name: string) => Chainable<any>;
+      umbracoPartialViewExists: (name: string) => Chainable<boolean>;
+      savePartialView: (name: any) => Chainable<void>;
+      umbracoErrorNotification: () => Chainable<any>;
     }
   }
 }

--- a/src/cypress/commands/command.ts
+++ b/src/cypress/commands/command.ts
@@ -69,7 +69,7 @@ export class Command {
   public registerCypressCommands(customRelativeBackOfficePath?: string): void {
     const relativeBackOfficePath = customRelativeBackOfficePath || '/umbraco';
     Cypress.Server.defaults({
-      whitelist: (xhr) => {
+      ignore: (xhr) => {
         if (new URL(xhr.url).pathname?.startsWith(relativeBackOfficePath)) {
           return true;
         }

--- a/src/cypress/commands/command.ts
+++ b/src/cypress/commands/command.ts
@@ -63,6 +63,7 @@ import SaveMacro from './saveMacro';
 import SaveCodeFile from './saveCodeFile';
 import SaveScript from './saveScript';
 import UmbracoScriptExists from './umbracoScriptExists'
+import UmbracoVerifyScriptContent from './umbracoVerifyScriptContent';
 
 export class Command {
   public registerCypressCommands(customRelativeBackOfficePath?: string): void {
@@ -141,5 +142,6 @@ export class Command {
     new SaveCodeFile(relativeBackOfficePath).registerCommand();
     new SaveScript(relativeBackOfficePath).registerCommand();
     new UmbracoScriptExists(relativeBackOfficePath).registerCommand();
+    new UmbracoVerifyScriptContent(relativeBackOfficePath).registerCommand();
   }
 }

--- a/src/cypress/commands/command.ts
+++ b/src/cypress/commands/command.ts
@@ -64,6 +64,7 @@ import SaveCodeFile from './saveCodeFile';
 import SaveScript from './saveScript';
 import UmbracoScriptExists from './umbracoScriptExists'
 import UmbracoVerifyScriptContent from './umbracoVerifyScriptContent';
+import SaveFolder from './saveFolder';
 
 export class Command {
   public registerCypressCommands(customRelativeBackOfficePath?: string): void {
@@ -143,5 +144,6 @@ export class Command {
     new SaveScript(relativeBackOfficePath).registerCommand();
     new UmbracoScriptExists(relativeBackOfficePath).registerCommand();
     new UmbracoVerifyScriptContent(relativeBackOfficePath).registerCommand();
+    new SaveFolder(relativeBackOfficePath).registerCommand();
   }
 }

--- a/src/cypress/commands/command.ts
+++ b/src/cypress/commands/command.ts
@@ -60,6 +60,8 @@ import UmbracoErrorNotification from './umbracoErrorNotification';
 import SavePartialView from './savePartialView';
 import UmbracoPartialViewExists from './umbracoPartialViewExists'
 import SaveMacro from './saveMacro';
+import SaveCodeFile from './saveCodeFile';
+import SaveScript from './saveScript';
 
 export class Command {
   public registerCypressCommands(customRelativeBackOfficePath?: string): void {
@@ -135,5 +137,7 @@ export class Command {
     new SavePartialView(relativeBackOfficePath).registerCommand();
     new UmbracoPartialViewExists(relativeBackOfficePath).registerCommand();
     new SaveMacro(relativeBackOfficePath).registerCommand();
+    new SaveCodeFile(relativeBackOfficePath).registerCommand();
+    new SaveScript(relativeBackOfficePath).registerCommand();
   }
 }

--- a/src/cypress/commands/command.ts
+++ b/src/cypress/commands/command.ts
@@ -65,6 +65,7 @@ import SaveScript from './saveScript';
 import UmbracoScriptExists from './umbracoScriptExists'
 import UmbracoVerifyScriptContent from './umbracoVerifyScriptContent';
 import SaveFolder from './saveFolder';
+import UmbracoApiRequest from './umbracoApiRequest';
 
 export class Command {
   public registerCypressCommands(customRelativeBackOfficePath?: string): void {
@@ -145,5 +146,6 @@ export class Command {
     new UmbracoScriptExists(relativeBackOfficePath).registerCommand();
     new UmbracoVerifyScriptContent(relativeBackOfficePath).registerCommand();
     new SaveFolder(relativeBackOfficePath).registerCommand();
+    new UmbracoApiRequest(relativeBackOfficePath).registerCommand();
   }
 }

--- a/src/cypress/commands/command.ts
+++ b/src/cypress/commands/command.ts
@@ -62,6 +62,7 @@ import UmbracoPartialViewExists from './umbracoPartialViewExists'
 import SaveMacro from './saveMacro';
 import SaveCodeFile from './saveCodeFile';
 import SaveScript from './saveScript';
+import UmbracoScriptExists from './umbracoScriptExists'
 
 export class Command {
   public registerCypressCommands(customRelativeBackOfficePath?: string): void {
@@ -139,5 +140,6 @@ export class Command {
     new SaveMacro(relativeBackOfficePath).registerCommand();
     new SaveCodeFile(relativeBackOfficePath).registerCommand();
     new SaveScript(relativeBackOfficePath).registerCommand();
+    new UmbracoScriptExists(relativeBackOfficePath).registerCommand();
   }
 }

--- a/src/cypress/commands/postFile.ts
+++ b/src/cypress/commands/postFile.ts
@@ -10,7 +10,7 @@ export default class PostFile extends CommandBase {
     const formData = new FormData();
 
     cy.fixture(fileName, 'base64').then((fileFixture) => {
-      Cypress.Blob.base64StringToBlob(fileFixture).then((blob) => {
+      const blob = Cypress.Blob.base64StringToBlob(fileFixture);
         const testFile = new File([blob], fileName);
         formData.append('file', testFile);
         cy.getCookie('UMB-XSRF-TOKEN').then((token) => {
@@ -32,7 +32,6 @@ export default class PostFile extends CommandBase {
               return JsonHelper.getBody(res.response);
             });
         });
-      });
     });
   }
 }

--- a/src/cypress/commands/postRequest.ts
+++ b/src/cypress/commands/postRequest.ts
@@ -10,7 +10,7 @@ export default class PostRequest extends CommandBase {
 
     cy.getCookie('UMB-XSRF-TOKEN').then((token) => {
       cy.server({
-        whitelist: (request) => {
+        ignore: (request) => {
           return;
         },
       });

--- a/src/cypress/commands/saveCodeFile.ts
+++ b/src/cypress/commands/saveCodeFile.ts
@@ -11,20 +11,7 @@ export default class SaveCodeFile extends CommandBase{
       return;
     }
 
-    return cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
-      cy.request({
-        method: 'POST',
-        url: this.relativeBackOfficePath + '/backoffice/UmbracoApi/CodeFile/PostSave',
-        body: codeFile,
-        timeout: 90000,
-        json: true,
-        headers: {
-          Accept: 'application/json',
-          'X-UMB-XSRF-TOKEN': token.value,
-        },
-      }).then((response) => {
-        return JsonHelper.getBody(response);
-      });
-    });
+    return cy.umbracoApiRequest(
+      this.relativeBackOfficePath + '/backoffice/UmbracoApi/CodeFile/PostSave', 'POST', codeFile);
   }
 }

--- a/src/cypress/commands/saveCodeFile.ts
+++ b/src/cypress/commands/saveCodeFile.ts
@@ -1,0 +1,30 @@
+import CommandBase from './commandBase';
+import { JsonHelper } from '../../helpers/jsonHelper';
+
+export default class SaveCodeFile extends CommandBase{
+  commandName = 'saveCodeFile';
+
+  method(codeFile) {
+    const cy = this.cy;
+
+    if (codeFile == null) {
+      return;
+    }
+
+    return cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
+      cy.request({
+        method: 'POST',
+        url: this.relativeBackOfficePath + '/backoffice/UmbracoApi/CodeFile/PostSave',
+        body: codeFile,
+        timeout: 90000,
+        json: true,
+        headers: {
+          Accept: 'application/json',
+          'X-UMB-XSRF-TOKEN': token.value,
+        },
+      }).then((response) => {
+        return JsonHelper.getBody(response);
+      });
+    });
+  }
+}

--- a/src/cypress/commands/saveCodeFile.ts
+++ b/src/cypress/commands/saveCodeFile.ts
@@ -1,5 +1,4 @@
 import CommandBase from './commandBase';
-import { JsonHelper } from '../../helpers/jsonHelper';
 
 export default class SaveCodeFile extends CommandBase{
   commandName = 'saveCodeFile';

--- a/src/cypress/commands/saveDataType.ts
+++ b/src/cypress/commands/saveDataType.ts
@@ -1,5 +1,4 @@
 import CommandBase from './commandBase';
-import { JsonHelper } from '../../helpers/jsonHelper';
 
 export default class SaveDataType extends CommandBase {
   commandName = 'saveDataType';
@@ -11,20 +10,6 @@ export default class SaveDataType extends CommandBase {
       return;
     }
 
-    return cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
-      cy.request({
-        method: 'POST',
-        url: this.relativeBackOfficePath + '/backoffice/UmbracoApi/DataType/PostSave',
-        body: dataType,
-        timeout: 90000,
-        json: true,
-        headers: {
-          Accept: 'application/json',
-          'X-UMB-XSRF-TOKEN': token.value,
-        },
-      }).then((response) => {
-        return JsonHelper.getBody(response);
-      });
-    });
+    return cy.umbracoApiRequest(this.relativeBackOfficePath + '/backoffice/UmbracoApi/DataType/PostSave', 'POST', dataType);
   }
 }

--- a/src/cypress/commands/saveDocumentType.ts
+++ b/src/cypress/commands/saveDocumentType.ts
@@ -1,5 +1,4 @@
 import CommandBase from './commandBase';
-import { JsonHelper } from '../../helpers/jsonHelper';
 
 export default class SaveDocumentType extends CommandBase {
   commandName = 'saveDocumentType';
@@ -10,22 +9,7 @@ export default class SaveDocumentType extends CommandBase {
     if (docType == null) {
       return;
     }
-    return cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
-      return cy
-        .request({
-          method: 'POST',
-          url: this.relativeBackOfficePath + '/backoffice/UmbracoApi/ContentType/PostSave',
-          body: docType,
-          timeout: 90000,
-          json: true,
-          headers: {
-            Accept: 'application/json',
-            'X-UMB-XSRF-TOKEN': token.value,
-          },
-        })
-        .then((response) => {
-          return JsonHelper.getBody(response);
-        });
-    });
+
+    return cy.umbracoApiRequest(this.relativeBackOfficePath + '/backoffice/UmbracoApi/ContentType/PostSave', 'POST', docType);
   }
 }

--- a/src/cypress/commands/saveFolder.ts
+++ b/src/cypress/commands/saveFolder.ts
@@ -1,0 +1,29 @@
+import CommandBase from './commandBase';
+import { JsonHelper } from '../../helpers/jsonHelper';
+
+
+export default class SaveFolder extends CommandBase{
+  commandName = 'saveFolder';
+
+  method(section, name) {
+    const cy = this.cy;
+
+    if (section == null) {
+      return;
+    }
+
+    return cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
+      cy.request({
+        method: 'POST',
+        url: this.relativeBackOfficePath + '/backoffice/UmbracoApi/CodeFile/PostCreateContainer?type='+ section + '&parentId=-1&name=' + name,
+        timeout: 90000,
+        headers: {
+          Accept: 'application/json, text/plain, */*',
+          'X-UMB-XSRF-TOKEN': token.value,
+        },
+      }).then((response) => {
+        return JsonHelper.getBody(response);
+      });
+    });
+  }
+}

--- a/src/cypress/commands/saveForm.ts
+++ b/src/cypress/commands/saveForm.ts
@@ -1,6 +1,5 @@
 import CommandBase from './commandBase';
-import { JsonHelper } from '../../helpers/jsonHelper';
-import faker from 'faker';
+
 export default class SaveForm extends CommandBase {
   commandName = 'saveForm';
 
@@ -10,19 +9,7 @@ export default class SaveForm extends CommandBase {
     if (form == null) {
       return;
     }
-    return cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
-      cy.request({
-        method: 'POST',
-        url: this.relativeBackOfficePath + '/backoffice/UmbracoForms/Form/SaveForm',
-        body: form,
-        followRedirect: true,
-        headers: {
-          Accept: 'application/json',
-          'X-UMB-XSRF-TOKEN': token.value,
-        },
-      }).then((response) => {
-        return JsonHelper.getBody(response);
-      });
-    });
+
+    return cy.umbracoApiRequest(this.relativeBackOfficePath + '/backoffice/UmbracoForms/Form/SaveForm', 'POST', form);
   }
 }

--- a/src/cypress/commands/saveMacro.ts
+++ b/src/cypress/commands/saveMacro.ts
@@ -1,5 +1,4 @@
 import CommandBase from './commandBase';
-import { JsonHelper } from '../../helpers/jsonHelper';
 
 export default class SaveMacro extends CommandBase{
   commandName = 'saveMacro';
@@ -10,18 +9,6 @@ export default class SaveMacro extends CommandBase{
       return;
     }
 
-    return cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
-      cy.request({
-        method: 'POST',
-        url: this.relativeBackOfficePath + '/backoffice/UmbracoApi/Macros/Create?name=' + name,
-        timeout: 90000,
-        headers: {
-          Accept: 'application/json',
-          'X-UMB-XSRF-TOKEN': token.value,
-        },
-      }).then((response) => {
-        return JsonHelper.getBody(response);
-      });
-    });
+    return cy.umbracoApiRequest(this.relativeBackOfficePath + '/backoffice/UmbracoApi/Macros/Create?name=' + name, 'POST')
   }
 }

--- a/src/cypress/commands/savePartialView.ts
+++ b/src/cypress/commands/savePartialView.ts
@@ -1,30 +1,5 @@
-import CommandBase from './commandBase';
-import { JsonHelper } from '../../helpers/jsonHelper';
+import SaveCodeFile from './saveCodeFile'
 
-export default class SavePartialView extends CommandBase{
+export default class SavePartialView extends SaveCodeFile{
   commandName = 'savePartialView';
-
-  method(partialView) {
-    const cy = this.cy;
-
-    if (partialView == null) {
-      return;
-    }
-
-    return cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
-      cy.request({
-        method: 'POST',
-        url: this.relativeBackOfficePath + '/backoffice/UmbracoApi/CodeFile/PostSave',
-        body: partialView,
-        timeout: 90000,
-        json: true,
-        headers: {
-          Accept: 'application/json',
-          'X-UMB-XSRF-TOKEN': token.value,
-        },
-      }).then((response) => {
-        return JsonHelper.getBody(response);
-      });
-    });
-  }
 }

--- a/src/cypress/commands/savePartialViewMacro.ts
+++ b/src/cypress/commands/savePartialViewMacro.ts
@@ -1,5 +1,4 @@
 import CommandBase from './commandBase';
-import { JsonHelper } from '../../helpers/jsonHelper';
 
 export default class SavePartialViewMacro extends CommandBase{
   commandName = 'savePartialViewMacro';
@@ -10,21 +9,7 @@ export default class SavePartialViewMacro extends CommandBase{
     if (partialViewMacro == null) {
       return;
     }
-
-    return cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
-      cy.request({
-        method: 'POST',
-        url: this.relativeBackOfficePath + '/backoffice/UmbracoApi/CodeFile/PostSave',
-        body: partialViewMacro,
-        timout: 90000,
-        json: true,
-        headers: {
-          Accept: 'application/json',
-          'X-UMB-XSRF-TOKEN': token.value,
-        },
-      }).then((response) => {
-        return JsonHelper.getBody(response);
-      })
-    })
+    
+    return cy.umbracoApiRequest(this.relativeBackOfficePath + '/backoffice/UmbracoApi/CodeFile/PostSave', 'POST', partialViewMacro);
   }
 }

--- a/src/cypress/commands/saveScript.ts
+++ b/src/cypress/commands/saveScript.ts
@@ -1,0 +1,5 @@
+import SaveCodeFile from './saveCodeFile';
+
+export default class SaveScript extends SaveCodeFile{
+  commandName = "saveScript";
+}

--- a/src/cypress/commands/saveTemplate.ts
+++ b/src/cypress/commands/saveTemplate.ts
@@ -1,5 +1,4 @@
 import CommandBase from './commandBase';
-import { JsonHelper } from '../../helpers/jsonHelper';
 
 export default class SaveTemplate extends CommandBase {
   commandName = 'saveTemplate';
@@ -10,21 +9,7 @@ export default class SaveTemplate extends CommandBase {
     if (template == null) {
       return;
     }
-    return cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
-      return cy
-        .request({
-          method: 'POST',
-          url: this.relativeBackOfficePath + '/backoffice/UmbracoApi/Template/PostSave',
-          body: template,
-          json: true,
-          headers: {
-            Accept: 'application/json',
-            'X-UMB-XSRF-TOKEN': token.value,
-          },
-        })
-        .then((response) => {
-          return JsonHelper.getBody(response);
-        });
-    });
+
+    return cy.umbracoApiRequest(this.relativeBackOfficePath + '/backoffice/UmbracoApi/Template/PostSave', 'POST', template);
   }
 }

--- a/src/cypress/commands/umbracoApiRequest.ts
+++ b/src/cypress/commands/umbracoApiRequest.ts
@@ -1,0 +1,33 @@
+import CommandBase from './commandBase';
+import { JsonHelper } from '../../helpers/jsonHelper';
+
+export default class UmbracoApiRequest extends CommandBase{
+  commandName = 'umbracoApiRequest';
+
+  method(url, method, body) {
+    const cy = this.cy;
+
+    if (url == null || url === "") {
+      return null;
+    }
+
+    return cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
+      cy.request({
+        method: method ?? 'GET',
+        url: url,
+        body: body,
+        timeout: 90000,
+        json: true,
+        headers: {
+          Accept: 'application/json',
+          'X-UMB-XSRF-TOKEN': token.value,
+        },
+      }).then((response) => {
+        if (response.isOkStatusCode) {
+          return JsonHelper.getBody(response);
+        }
+        return null;
+      });
+    });
+  }
+}

--- a/src/cypress/commands/umbracoFileExists.ts
+++ b/src/cypress/commands/umbracoFileExists.ts
@@ -1,4 +1,3 @@
-import { ResponseHelper } from '../../helpers/responseHelper'; 
 import CommandBase from './commandBase';
 
 export default class UmbracoFileExists extends CommandBase{
@@ -8,18 +7,8 @@ export default class UmbracoFileExists extends CommandBase{
   method(name) {
     const cy = this.cy;
 
-    cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => { 
-      cy.request({
-        method: 'GET',
-        url: this._relativeBackOfficePath + this._endPoint,
-        followRedirect: true,
-        headers: {
-          Accept: 'application/json',
-          'X-UMB-XSRF-TOKEN': token.value,
-        },
-        log: false,
-      }).then((response) => { 
-        const searchBody = ResponseHelper.getResponseBody(response);
+    cy.umbracoApiRequest(this._relativeBackOfficePath + this._endPoint)
+      .then((searchBody) => {
         if (searchBody.length > 0) {
           for (const sb of searchBody) {
             if (sb.name === name) {
@@ -28,7 +17,6 @@ export default class UmbracoFileExists extends CommandBase{
           }
         }
         return false;
-       });
-     });
+      });
   }
 }

--- a/src/cypress/commands/umbracoFileExists.ts
+++ b/src/cypress/commands/umbracoFileExists.ts
@@ -1,0 +1,34 @@
+import { ResponseHelper } from '../../helpers/responseHelper'; 
+import CommandBase from './commandBase';
+
+export default class UmbracoFileExists extends CommandBase{
+  _commandName = 'umbracoFileExists';
+  _endPoint;
+
+  method(name) {
+    const cy = this.cy;
+
+    cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => { 
+      cy.request({
+        method: 'GET',
+        url: this._relativeBackOfficePath + this._endPoint,
+        followRedirect: true,
+        headers: {
+          Accept: 'application/json',
+          'X-UMB-XSRF-TOKEN': token.value,
+        },
+        log: false,
+      }).then((response) => { 
+        const searchBody = ResponseHelper.getResponseBody(response);
+        if (searchBody.length > 0) {
+          for (const sb of searchBody) {
+            if (sb.name === name) {
+              return true;
+            }
+          }
+        }
+        return false;
+       });
+     });
+  }
+}

--- a/src/cypress/commands/umbracoMacroExists.ts
+++ b/src/cypress/commands/umbracoMacroExists.ts
@@ -1,37 +1,6 @@
-import CommandBase from './commandBase';
-import { ResponseHelper } from '../../helpers/responseHelper';
+import UmbracoFileExists from './umbracoFileExists';
 
-export default class UmbracoMacroExists extends CommandBase {
+export default class UmbracoMacroExists extends UmbracoFileExists {
   _commandName = 'umbracoMacroExists';
-
-  method(name) {
-    const cy = this.cy;
-
-    cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
-      // Request list of macros
-      cy.request({
-        method: 'GET',
-        url: this._relativeBackOfficePath + '/backoffice/UmbracoTrees/MacrosTree/GetNodes?id=-1',
-        followRedirect: true,
-        headers: {
-          Accept: 'application/json',
-          'X-UMB-XSRF-TOKEN': token.value,
-        },
-        log: false,
-        // search for macro by name 
-      }).then((response) => {
-        const searchBody = ResponseHelper.getResponseBody(response);
-        if (searchBody.length > 0) {
-          for (const sb of searchBody) {
-            if (sb.name === name) {
-              // Macro found, return true
-              return true;
-            }
-          }
-        }
-        // No macro found, return false
-        return false;
-      });
-    });
-  }
+  _endPoint = '/backoffice/UmbracoTrees/MacrosTree/GetNodes?id=-1';
 }

--- a/src/cypress/commands/umbracoPartialViewExists.ts
+++ b/src/cypress/commands/umbracoPartialViewExists.ts
@@ -1,37 +1,6 @@
-import CommandBase from './commandBase';
-import { ResponseHelper } from '../../helpers/responseHelper';
+import UmbracoFileExists from './umbracoFileExists';
 
-export default class UmbracoPartialViewExists extends CommandBase {
+export default class UmbracoPartialViewExists extends UmbracoFileExists {
   _commandName = 'umbracoPartialViewExists';
-
-  method(name) {
-    const cy = this.cy;
-    
-    cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
-      // Request list of partial views
-      cy.request({
-        method: 'GET',
-        url: this._relativeBackOfficePath + '/backoffice/UmbracoTrees/PartialViewsTree/GetNodes?id=-1',
-        followRedirect: true,
-        headers: {
-          Accept: 'application/json',
-          'X-UMB-XSRF-TOKEN': token.value,
-        },
-        log: false,
-        // search for partial view by name 
-      }).then((response) => {
-        const searchBody = ResponseHelper.getResponseBody(response);
-        if (searchBody.length > 0) {
-          for (const sb of searchBody) {
-            if (sb.name === name) {
-              // Partial view found, return true
-              return true;
-            }
-          }
-        }
-        // No partial view found, return false
-        return false;
-      });
-    });
-  }
+  _endPoint = '/backoffice/UmbracoTrees/PartialViewsTree/GetNodes?id=-1';
 }

--- a/src/cypress/commands/umbracoScriptExists.ts
+++ b/src/cypress/commands/umbracoScriptExists.ts
@@ -1,35 +1,6 @@
-import CommanBase from './commandBase';
-import { ResponseHelper } from '../../helpers/responseHelper'; 
-import CommandBase from './commandBase';
+import UmbracoFileExists from './umbracoFileExists';
 
-// TODO: All these "exists" are very similar, make a base class or something?
-export default class UmbracoScriptExists extends CommandBase{
+export default class UmbracoScriptExists extends UmbracoFileExists{
   _commandName = 'umbracoScriptExists';
-
-  method(name) {
-    const cy = this.cy;
-
-    cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => { 
-      cy.request({
-        method: 'GET',
-        url: this._relativeBackOfficePath + '/BackOffice/Api/ScriptsTree/GetNodes?id=-1',
-        followRedirect: true,
-        headers: {
-          Accept: 'application/json',
-          'X-UMB-XSRF-TOKEN': token.value,
-        },
-        log: false,
-      }).then((response) => { 
-        const searchBody = ResponseHelper.getResponseBody(response);
-        if (searchBody.length > 0) {
-          for (const sb of searchBody) {
-            if (sb.name === name) {
-              return true;
-            }
-          }
-        }
-        return false;
-       });
-     });
-  }
+  _endPoint = '/BackOffice/Api/ScriptsTree/GetNodes?id=-1';
 }

--- a/src/cypress/commands/umbracoScriptExists.ts
+++ b/src/cypress/commands/umbracoScriptExists.ts
@@ -1,0 +1,35 @@
+import CommanBase from './commandBase';
+import { ResponseHelper } from '../../helpers/responseHelper'; 
+import CommandBase from './commandBase';
+
+// TODO: All these "exists" are very similar, make a base class or something?
+export default class UmbracoScriptExists extends CommandBase{
+  _commandName = 'umbracoScriptExists';
+
+  method(name) {
+    const cy = this.cy;
+
+    cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => { 
+      cy.request({
+        method: 'GET',
+        url: this._relativeBackOfficePath + '/BackOffice/Api/ScriptsTree/GetNodes?id=-1',
+        followRedirect: true,
+        headers: {
+          Accept: 'application/json',
+          'X-UMB-XSRF-TOKEN': token.value,
+        },
+        log: false,
+      }).then((response) => { 
+        const searchBody = ResponseHelper.getResponseBody(response);
+        if (searchBody.length > 0) {
+          for (const sb of searchBody) {
+            if (sb.name === name) {
+              return true;
+            }
+          }
+        }
+        return false;
+       });
+     });
+  }
+}

--- a/src/cypress/commands/umbracoVerifyScriptContent.ts
+++ b/src/cypress/commands/umbracoVerifyScriptContent.ts
@@ -1,0 +1,26 @@
+import CommandBase from './commandBase';
+
+export default class UmbracoVerifyScriptContent extends CommandBase{
+  _commandName = 'umbracoVerifyScriptContent';
+
+  method(fileName, expectedContent) {
+    const cy = this.cy;
+
+    cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => { 
+      cy.request({
+        method: 'GET',
+        url: '/scripts/' + fileName,
+        followRedirect: true,
+        headers: {
+          Accept: 'application/javascript',
+          'X-UMB-XSRF-TOKEN': token.value,
+        },
+        log: false,
+      }).then((response) => {
+        if (response.body === expectedContent) return true;
+        return false;
+      })
+     });
+
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,8 @@ export { PartialViewMacroBuilder } from './cms/builders/partialViewMacros/partia
 /* PartialViewBuilders */
 export { PartialViewBuilder } from './cms/builders/partialViews/partialViewBuilder';
 
+export{ ScriptBuilder } from './cms/builders/scriptbuilder'
+
 /* Contents */
 // export * from './cms/templates/'
 export { FormPickerTemplate } from './cms/templates/formPickerTemplate';


### PR DESCRIPTION
1. Updated cypress to 5.0
    * Changed whitelist to ignore to fix breaking changes
2. Added new methods to chainable meaning you no longer have to use `cy.umbracoMacroExists(name).then(exists => { expect(exists).to.be.true; });` but can just do  `cy.umbracoMacroExists(name).should('be.true');`
3. Added 3 new javascript test
4. Moved test fixes from umbraco project
5. Added a SaveCodeFile baseclass making classes like SavePartialView a lot simpler
6. Added UmbracoFileExists base class for <fileType>Exists methods
7. Added UmbracoApiRequest resolving #26 and applied it to a lot of methods
