### PR TITLE
Extending ContentBuilder

### DIFF
--- a/src/cms/builders/content/contentBuilder.ts
+++ b/src/cms/builders/content/contentBuilder.ts
@@ -19,8 +19,19 @@ export class ContentBuilder {
     this.contentTypeAlias = contentTypeAlias;
     return this;
   }
+
   withTemplateAlias(templateAlias) {
     this.templateAlias = templateAlias;
+    return this;
+  }
+
+  withAction(action) {
+    this.action = action;
+    return this;
+  }
+
+  withParent(parentId) {
+    this.parentId = parentId;
     return this;
   }
 


### PR DESCRIPTION
Tests for Content need to be refactored to use the API for saving content, therefore modifications to the **ContentBuilder** are necessary:

- added `withAction(...)` and `withParent(...)`

_Note: By the time of review and release have a look at the guessed package version in the [PR](https://github.com/umbraco/Umbraco-CMS/pull/8622) of the CMS (currently set to 1.0.0-beta-**49** - version is already bumped up with 1)_