### PR TITLE
Bugfix: typescript loads as javascripts

### DIFF
--- a/src/cypress/commands/umbracoCreateDocTypeWithContent.ts
+++ b/src/cypress/commands/umbracoCreateDocTypeWithContent.ts
@@ -1,39 +1,35 @@
 import CommandBase from './commandBase';
-import {
-    DocumentTypeBuilder,
-    ContentBuilder
-} from '../../../src';
-
+import { DocumentTypeBuilder } from '../../cms/builders/documentTypes/documentTypeBuilder';
+import { ContentBuilder } from '../../cms/builders/content/contentBuilder';
 export default class UmbracoCreateDocTypeWithContent extends CommandBase {
   _commandName = 'umbracoCreateDocTypeWithContent';
 
   method(name, alias, dataTypeBuilder) {
-
     cy.saveDataType(dataTypeBuilder).then((dataType) => {
-        // Create a document type using the data type
-        const docType = new DocumentTypeBuilder()
-            .withName(name)
-            .withAlias(alias)
-            .withAllowAsRoot(true)
-            .withDefaultTemplate(alias)
-            .addGroup()
-            .addCustomProperty(dataType['id'])
-            .withAlias('umbracoTest')
-            .done()
-            .done()
-            .build();
+      // Create a document type using the data type
+      const docType = new DocumentTypeBuilder()
+        .withName(name)
+        .withAlias(alias)
+        .withAllowAsRoot(true)
+        .withDefaultTemplate(alias)
+        .addGroup()
+        .addCustomProperty(dataType['id'])
+        .withAlias('umbracoTest')
+        .done()
+        .done()
+        .build();
 
-        cy.saveDocumentType(docType).then((generatedDocType) => {
-            const contentNode = new ContentBuilder()
-                .withContentTypeAlias(generatedDocType["alias"])
-                .addVariant()
-                .withName(name)
-                .withSave(true)
-                .done()
-                .build();
+      cy.saveDocumentType(docType).then((generatedDocType) => {
+        const contentNode = new ContentBuilder()
+          .withContentTypeAlias(generatedDocType['alias'])
+          .addVariant()
+          .withName(name)
+          .withSave(true)
+          .done()
+          .build();
 
-            cy.saveContent(contentNode);
-        });
+        cy.saveContent(contentNode);
+      });
     });
   }
 }

--- a/src/forms/builders/formBuilder.ts
+++ b/src/forms/builders/formBuilder.ts
@@ -54,7 +54,7 @@ export class FormBuilder implements IBuilder {
     this.formPageBuilders.push(builder);
     return builder;
   }
-  addFormWorkflowType(executeOn): FormWorkflowBuilder {
+  addFormWorkflowType(executeOn : ExecuteOn): FormWorkflowBuilder {
     const builder = new FormWorkflowBuilder(this);
     executeOn === ExecuteOn.onAprrove ? this.onApprove.push(builder) : this.onSubmit.push(builder);
     return builder;

--- a/src/forms/builders/formBuilder.ts
+++ b/src/forms/builders/formBuilder.ts
@@ -2,10 +2,10 @@ import { FormPageBuilder } from './formPageBuilder';
 import { IBuilder } from './iBuilder';
 import { FormWorkflowBuilder } from './workflows/formWorkflowBuilder';
 
-const ExecuteOn = {
-  onSubmit: 0,
-  onAprrove: 1,
-};
+enum ExecuteOn {
+  onSubmit = 0,
+  onAprrove = 1,
+}
 export class FormBuilder implements IBuilder {
   created;
   cssClass;


### PR DESCRIPTION
# Notes
- Updated umbracoCreateDocTypeWithContent to import more specific filepaths
- Reverted formbuilder.ts as the fault is in that loads as js, not that enum should be wrong