### PR TITLE
Created new reset user language method and implemented new test

### DIFF
--- a/cypress/integration/HelpPanel/systemInformation.ts
+++ b/cypress/integration/HelpPanel/systemInformation.ts
@@ -21,24 +21,20 @@ context('System Information', () => {
         cy.contains('Current Culture').parent().should('contain', 'en-US');
         cy.contains('Current UI Culture').parent().should('contain', 'en-US');
     });
+    
+    it('Checks language displays correctly after switching', () => {
 
-    context('Language switching', () => {
-
-        it('Checks language displays correctly after switching', () => {
-
-            //Navigate to edit user and change language
-            cy.get('[data-element="global-user"]').click();
-            cy.get('[alias="editUser"]').click();
-            cy.get('[name="culture"]').select('string:da-DK', {timeout: 10000, force: true});
-            cy.umbracoButtonByLabelKey('buttons_save').click({force: true});
-            //Refresh site to display new language
-            cy.reload();
-            openSystemInformation();
-            //Assert
-            cy.contains('Current Culture').parent().should('contain', 'da-DK');
-            cy.contains('Current UI Culture').parent().should('contain', 'da-DK');
-            cy.get('.umb-button__content').last().click();
-            cy.reload();
-        });
+        //Navigate to edit user and change language
+        cy.get('[data-element="global-user"]').click();
+        cy.get('[alias="editUser"]').click();
+        cy.get('[name="culture"]').select('string:da-DK', {timeout: 10000, force: true});
+        cy.umbracoButtonByLabelKey('buttons_save').click({force: true});
+        //Refresh site to display new language
+        cy.reload();
+        openSystemInformation();
+        //Assert
+        cy.contains('Current Culture').parent().should('contain', 'da-DK');
+        cy.contains('Current UI Culture').parent().should('contain', 'da-DK');
+        cy.get('.umb-button__content').last().click();
     });
 });

--- a/cypress/integration/HelpPanel/systemInformation.ts
+++ b/cypress/integration/HelpPanel/systemInformation.ts
@@ -1,0 +1,44 @@
+/// <reference types="Cypress" />
+
+function openSystemInformation(){
+    //We have to wait for page to load, if the site is slow
+    cy.get('[data-element="global-help"]').should('be.visible', {timeout:10000}).click();
+    cy.get('.umb-help-list-item').last().should('be.visible').click();
+    cy.get('.umb-drawer-content').scrollTo('bottom', {ensureScrollable : false});
+}
+
+context('System Information', () => {
+
+    beforeEach(() => {
+        //arrange
+        cy.umbracoLogin(Cypress.env('username'), Cypress.env('password'));
+        cy.umbracoEnsureUserLanguageIsReset();
+    });
+
+    it('Check System Info Displays', () => {
+        openSystemInformation();
+        cy.get('.table').find('tr').should('have.length', 10);
+        cy.contains('Current Culture').parent().should('contain', 'en-US');
+        cy.contains('Current UI Culture').parent().should('contain', 'en-US');
+    });
+
+    context('Language switching', () => {
+
+        it('Checks language displays correctly after switching', () => {
+
+            //Navigate to edit user and change language
+            cy.get('[data-element="global-user"]').click();
+            cy.get('[alias="editUser"]').click();
+            cy.get('[name="culture"]').select('string:da-DK', {timeout: 10000, force: true});
+            cy.umbracoButtonByLabelKey('buttons_save').click({force: true});
+            //Refresh site to display new language
+            cy.reload();
+            openSystemInformation();
+            //Assert
+            cy.contains('Current Culture').parent().should('contain', 'da-DK');
+            cy.contains('Current UI Culture').parent().should('contain', 'da-DK');
+            cy.get('.umb-button__content').last().click();
+            cy.reload();
+        });
+    });
+});

--- a/src/cypress/commands/command.ts
+++ b/src/cypress/commands/command.ts
@@ -25,6 +25,7 @@ import UmbracoButtonByLabelKey from './umbracoButtonByLabelKey';
 import UmbracoEditorHeaderName from './umbracoEditorHeaderName';
 import UmbracoEnsureUserEmailNotExists from './umbracoEnsureUserEmailNotExists';
 import UmbracoEnsureUserGroupNameNotExists from './umbracoEnsureUserGroupNameNotExists';
+import UmbracoEnsureUserLanguageIsReset from './umbracoEnsureUserLanguageIsReset';
 import UmbracoTreeItem from './umbracoTreeItem';
 import UmbracoContextMenuAction from './umbracoContextMenuAction';
 import UmbracoEnsureRelationTypeNameNotExists from './umbracoEnsureRelationTypeNameNotExists';
@@ -131,6 +132,7 @@ export class Command {
     new UmbracoEnsureUserEmailNotExists(relativeBackOfficePath).registerCommand();
     new UmbracoEnsureMemberEmailNotExists(relativeBackOfficePath).registerCommand();
     new UmbracoEnsureUserGroupNameNotExists(relativeBackOfficePath).registerCommand();
+    new UmbracoEnsureUserLanguageIsReset(relativeBackOfficePath).registerCommand();
     new UmbracoEnsureRelationTypeNameNotExists(relativeBackOfficePath).registerCommand();
     new UmbracoEnsureDocumentTypeNameNotExists(relativeBackOfficePath).registerCommand();
     new UmbracoEnsureMultipleDocumentTypeNameNotExists(relativeBackOfficePath).registerCommand();

--- a/src/cypress/commands/umbracoEnsureUserLanguageIsReset.ts
+++ b/src/cypress/commands/umbracoEnsureUserLanguageIsReset.ts
@@ -1,0 +1,42 @@
+import CommandBase from './commandBase';
+import { JsonHelper } from '../../helpers/jsonHelper';
+
+export default class UmbracoEnsureUserLanguageIsReset extends CommandBase {
+  _commandName = 'umbracoEnsureUserLanguageIsReset';
+
+  method() {
+    const cy = this.cy;
+    cy.log('hej');
+    cy.getCookie('UMB-XSRF-TOKEN', { log: false }).then((token) => {
+      cy.request({
+        method: 'GET',
+        url:
+          this._relativeBackOfficePath +
+          '/backoffice/umbracoapi/authentication/GetCurrentUser',
+        followRedirect: true,
+        headers: {
+          Accept: 'application/json',
+          'X-UMB-XSRF-TOKEN': token.value,
+        },
+        log: false,
+      }).then((response) => {
+        const searchBody = JsonHelper.getBody(response);
+        cy.log(searchBody);
+        return cy.umbracoApiRequest(
+            this.relativeBackOfficePath + '/backoffice/umbracoapi/users/PostSaveUser',
+            'POST',
+            {
+                id: searchBody.id,
+                parentId: -1,
+                name: searchBody.name,
+                username: searchBody.email,
+                culture: "en-US",
+                email: searchBody.email,
+                startContentIds: [],
+                startMediaIds: [],
+                userGroups: searchBody.userGroups
+            });
+      });
+    });
+  }
+}


### PR DESCRIPTION
# Notes 
- Implemented new systemInformation test
- Implemented new method that resets the Users language

# How to test
- Go to the v9/feature/debug-dashboard branch
- Run `npm install` & `npm run build` to build the frontend
- Run the cypress test with `npm install` & `npm run cypress:open`
- They should all pass