### PR TITLE
Update umbracoLogin

### DIFF
--- a/src/cypress/commands/umbracoLogin.ts
+++ b/src/cypress/commands/umbracoLogin.ts
@@ -54,8 +54,12 @@ export default class UmbracoLogin extends CommandBase {
                     }
                   }
                 }
-                if (toursClosed || umbEmailMarketingDisabled === false) {
+                if (toursClosed) {
                   cy.get('.umb-tour-step', { timeout: 60000 }).should('be.visible'); // We now due to the api calls this will be shown, but slow computers can take a while
+                  cy.get('.underline').click();
+                }
+                else{
+                  cy.get('.umb-tour__popover', {timeout: 60000}).should('be.visible');
                   cy.get('.umb-tour-step__close').click();
                 }
               }


### PR DESCRIPTION
This change have to be made, so we can actually run the system info tests locally without unattended installs.
This change makes it so we press to never show tours again (don't worry, tours test will automatically enable them again)

# Notes
- Updated umbracoLogin to press don't show tours again
- Updated umbracoLogin to press no thanks to email popup

# How to test
- Run the cypress test, the before-each loop should not fail