### PR TITLE
Add null check to umbracoApiRequest

### DIFF
--- a/src/cypress/commands/umbracoApiRequest.ts
+++ b/src/cypress/commands/umbracoApiRequest.ts
@@ -23,7 +23,7 @@ export default class UmbracoApiRequest extends CommandBase {
           'X-UMB-XSRF-TOKEN': token.value,
         },
       }).then((response) => {
-        if (response.isOkStatusCode) {
+        if (response.isOkStatusCode && response.body != null) {
           return JsonHelper.getBody(response);
         }
         return null;


### PR DESCRIPTION
# Notes
- Added null check
- Right now umbracoApiRequest will throw errors if the response does not have a body, IE if the API call just returns a status code

# How to test
- Create a package in the umbraco backoffice
- Try deleting the package with an API call using umbracoApiRequest 
`https://localhost:44331/umbraco/backoffice/umbracoapi/package/DeleteCreatedPackage?packageId={YOUR PACKAGE ID HERE}`