### PR TITLE
Fix DocumentTypeBuilder

### DIFF
--- a/src/cms/builders/documentTypes/documentTypeBuilder.ts
+++ b/src/cms/builders/documentTypes/documentTypeBuilder.ts
@@ -114,7 +114,7 @@ export class DocumentTypeBuilder {
       trashed: this.trashed || false,
       key,
       parentId: this.parentId || -1,
-      path: this.path || null,
+      path: this.path || "",
       allowCultureVariant: this.allowCultureVariant || false,
       isElement: this.isElement || false,
       defaultTemplate: this.defaultTemplate || null,


### PR DESCRIPTION
After the nullable reference type changes, and with <nullable> enabled in csproj, non-nullable properties will now fail when you call ModelState.IsValid (which makes sense, non-nullable properties should not be null), but this breaks a lot of our tests that uses the document type builder, this PR will remedy that